### PR TITLE
fix(修复layer弹层关闭按钮大小): 在全局样式中的对应类添加样式

### DIFF
--- a/src/element-variables.scss
+++ b/src/element-variables.scss
@@ -13,7 +13,7 @@ $--font-path: '~element-ui/lib/theme-chalk/fonts';
 }
 
 .vl-notify.vl-notify-alert h2.vl-notice-title .icon-remove{
-  font-size: 20px;
+  font-size: 20px !important;
 }
 .vl-notify.vl-notify-alert h2.vl-notice-title .lv-title {
   font-size: 18px;


### PR DESCRIPTION
给icon-remove添加!important